### PR TITLE
Fix bug no software serial in ESP32

### DIFF
--- a/PZEM004Tv30.cpp
+++ b/PZEM004Tv30.cpp
@@ -57,6 +57,7 @@ void printBuf(uint8_t* buffer, uint16_t len){
  * @param transmitPin TX pin
  * @param addr Slave address of device
 */
+#if defined(PZEM004_SOFTSERIAL)
 PZEM004Tv30::PZEM004Tv30(uint8_t receivePin, uint8_t transmitPin, uint8_t addr)
 {
     SoftwareSerial *port = new SoftwareSerial(receivePin, transmitPin);
@@ -65,6 +66,7 @@ PZEM004Tv30::PZEM004Tv30(uint8_t receivePin, uint8_t transmitPin, uint8_t addr)
     this->_isSoft = true;
     init(addr);
 }
+#endif
 
 /*!
  * PZEM004Tv30::PZEM004Tv30

--- a/PZEM004Tv30.h
+++ b/PZEM004Tv30.h
@@ -22,7 +22,7 @@
 #endif
 
 // #define PZEM004_NO_SWSERIAL
-#if (not defined(PZEM004_NO_SWSERIAL)) && (defined(__AVR__) || defined(ESP8266))
+#if (not defined(PZEM004_NO_SWSERIAL)) && (defined(__AVR__) || defined(ESP8266) && (not defined(ESP32)))
 #define PZEM004_SOFTSERIAL
 #endif
 
@@ -37,7 +37,9 @@
 class PZEM004Tv30
 {
 public:
+#if defined(PZEM004_SOFTSERIAL)
     PZEM004Tv30(uint8_t receivePin, uint8_t transmitPin, uint8_t addr=PZEM_DEFAULT_ADDR);
+#endif
     PZEM004Tv30(HardwareSerial* port, uint8_t addr=PZEM_DEFAULT_ADDR);
     ~PZEM004Tv30();
 


### PR DESCRIPTION
In Arduino core for the ESP32 compile has error because ESP32 not support SoftwareSerial so i fix this.