### PR TITLE
Remove SoftwareSerial from libdeps

### DIFF
--- a/library.json
+++ b/library.json
@@ -14,12 +14,5 @@
         "url": "https://github.com/mandulaj/PZEM-004T-v30"
     },
     "platforms": "*",
-    "version": "1.0.0",
-    "dependencies": [
-        {
-            "name": "EspSoftwareSerial",
-            "version": ">=3.2.0",
-            "platforms": "espressif8266"
-        }
-    ]
+    "version": "1.0.0"
 }


### PR DESCRIPTION
SoftwareSerial is bundled into esp8266 Arduino framework.
plerup/espsoftwareserial repo contains dev version that might be not compatible with stable Core
and result in build errors like this
```
oftwareSerial.h:132:9: error: 'int SoftwareSerial::availableForWrite()' marked override, but does not override
```