### PR TITLE
Update API for HW and SoftwareSerial interface

### DIFF
--- a/examples/PZEMChangeAddress/PZEMChangeAddress.ino
+++ b/examples/PZEMChangeAddress/PZEMChangeAddress.ino
@@ -24,9 +24,25 @@ Otherwise all connected modules will receive the same custom address.
  * For example the Arduino MEGA 2560
 */
 #if defined(ESP32)
-PZEM004Tv30 pzem(&Serial2, 16, 17);
+/*************************
+ *  ESP32 initialization
+ * ---------------------
+ * 
+ * The ESP32 HW Serial interface can be routed to any GPIO pin 
+ * Here we initialize the PZEM on Serial2 with RX/TX pins 16 and 17
+ */
+PZEM004Tv30 pzem(Serial2, 16, 17);
 #else
-PZEM004Tv30 pzem(&Serial2);
+/*************************
+ *  Arduino initialization
+ * ---------------------
+ * 
+ * Not all Arduino boards come with multiple HW Serial ports.
+ * Serial2 is for example available on the Arduino MEGA 2560 but not Arduino Uno!
+ * The ESP32 HW Serial interface can be routed to any GPIO pin 
+ * Here we initialize the PZEM on Serial2 with default pins
+ */
+PZEM004Tv30 pzem(Serial2);
 #endif
 
 /*******************************************

--- a/examples/PZEMHardSerial/PZEMHardSerial.ino
+++ b/examples/PZEMHardSerial/PZEMHardSerial.ino
@@ -14,16 +14,43 @@ pins.
 
 #include <PZEM004Tv30.h>
 
-/* Hardware Serial2 is only available on certain boards.
- * For example the Arduino MEGA 2560
+/* 
 */
 #if defined(ESP32)
-PZEM004Tv30 pzem(&Serial2, 16, 17);
+/*************************
+ *  ESP32 initialization
+ * ---------------------
+ * 
+ * The ESP32 HW Serial interface can be routed to any GPIO pin 
+ * Here we initialize the PZEM on Serial2 with RX/TX pins 16 and 17
+ */
+PZEM004Tv30 pzem(Serial2, 16, 17);
+#elif defined(ESP8266)
+/*************************
+ *  ESP8266 initialization
+ * ---------------------
+ * 
+ * Not all Arduino boards come with multiple HW Serial ports.
+ * Serial2 is for example available on the Arduino MEGA 2560 but not Arduino Uno!
+ * The ESP32 HW Serial interface can be routed to any GPIO pin 
+ * Here we initialize the PZEM on Serial2 with default pins
+ */
+PZEM004Tv30 pzem(Serial1);
 #else
-PZEM004Tv30 pzem(&Serial2);
+/*************************
+ *  Arduino initialization
+ * ---------------------
+ * 
+ * Not all Arduino boards come with multiple HW Serial ports.
+ * Serial2 is for example available on the Arduino MEGA 2560 but not Arduino Uno!
+ * The ESP32 HW Serial interface can be routed to any GPIO pin 
+ * Here we initialize the PZEM on Serial2 with default pins
+ */
+PZEM004Tv30 pzem(Serial2);
 #endif
 
 void setup() {
+    // Debugging Serial port
     Serial.begin(115200);
 
     // Uncomment in order to reset the internal energy counter
@@ -31,7 +58,7 @@ void setup() {
 }
 
 void loop() {
-        
+    // Print the custom address of the PZEM
     Serial.print("Custom Address:");
     Serial.println(pzem.readAddress(), HEX);
 

--- a/examples/PZEMSoftwareSerial/PZEMSoftwareSerial.ino
+++ b/examples/PZEMSoftwareSerial/PZEMSoftwareSerial.ino
@@ -10,15 +10,25 @@ serial interface will be used for communication with the module.
 */
 
 #include <PZEM004Tv30.h>
+#include <SoftwareSerial.h>
+
+#if defined(ESP32)
+    #error "Software Serial is not supported on the ESP32"
+#endif
 
 /* Use software serial for the PZEM
- * Pin 11 Rx (Connects to the Tx pin on the PZEM)
- * Pin 12 Tx (Connects to the Rx pin on the PZEM)
+ * Pin 12 Rx (Connects to the Tx pin on the PZEM)
+ * Pin 13 Tx (Connects to the Rx pin on the PZEM)
 */
-PZEM004Tv30 pzem(11, 12);
+#define RX_PIN 12
+#define TX_PIN 13
+
+SoftwareSerial pzemSWSerial(RX_PIN, TX_PIN);
+PZEM004Tv30 pzem(pzemSWSerial);
 
 void setup() {
-  Serial.begin(115200);
+    /* Debugging serial */
+    Serial.begin(115200);
 }
 
 void loop() {
@@ -56,9 +66,7 @@ void loop() {
         Serial.print("Energy: ");       Serial.print(energy,3);     Serial.println("kWh");
         Serial.print("Frequency: ");    Serial.print(frequency, 1); Serial.println("Hz");
         Serial.print("PF: ");           Serial.println(pf);
-
     }
-
 
     Serial.println();
     delay(2000);

--- a/src/PZEM004Tv30.h
+++ b/src/PZEM004Tv30.h
@@ -65,6 +65,7 @@ class PZEM004Tv30
 public:
 #if defined(PZEM004_SOFTSERIAL)
     /* This will be deprecated */
+    [[deprecated("Replaced by PZEM004Tv30(SoftwareSerial& port, uint8_t addr). Please pass the SoftwareSerial object instead: PZEM004Tv30(RX, TX)=>PZEM004Tv30(SWSerial)")]]
     PZEM004Tv30(uint8_t receivePin, uint8_t transmitPin, uint8_t addr=PZEM_DEFAULT_ADDR);
     
     /* SoftwareSerial version calls begin method */
@@ -79,11 +80,13 @@ public:
     PZEM004Tv30(HardwareSerial& port, uint8_t receivePin, uint8_t transmitPin, uint8_t addr=PZEM_DEFAULT_ADDR);
     
     // Deprecate passing pointer
+    [[deprecated("Replaced by PZEM004Tv30(HardwareSerial& port, uint8_t receivePin, uint8_t transmitPin, uint8_t addr). Please pass a reference instead of a pointer: PZEM004Tv30(&SerialX)=>PZEM004Tv30(SerialX)")]]
     PZEM004Tv30(HardwareSerial* port, uint8_t receivePin, uint8_t transmitPin, uint8_t addr=PZEM_DEFAULT_ADDR) : PZEM004Tv30(*port, receivePin, transmitPin, addr) {};
 #else
     PZEM004Tv30(HardwareSerial& port, uint8_t addr=PZEM_DEFAULT_ADDR);
     
     // Deprecate passing pointer
+    [[deprecated("Replaced by PZEM004Tv30(HardwareSerial& port, uint8_t addr). Please pass a reference instead of a pointer: PZEM004Tv30(&SerialX)=>PZEM004Tv30(SerialX)")]]
     PZEM004Tv30(HardwareSerial* port, uint8_t addr=PZEM_DEFAULT_ADDR) : PZEM004Tv30(*port, addr) {};
 #endif
     // Empty constructor for creating arrays


### PR DESCRIPTION
Getting `SoftwareSerial` to work across multiple platforms is a pain. And
atempting to abstract everything from the user turned out to be a source
of many problems. Such as #21 #41 #61 and #65 to name a few...

As a result, the library will move away from handling its own instance
of `SoftwareSerial` and instead utilize the `Stream` interface. During
instantiation, user will pass the SWSerial object as a reference which
will be cased to a Stream.

The HW inteface is also updated to utilize references instead of
pointers in order to make the API more streamlined. In the future
passing pointers will be completely deprecated.