### PR TITLE
fix building with 'PZEM004_NO_SWSERIAL' under esp8266

### DIFF
--- a/examples/PZEMHardSerial/PZEMHardSerial.cpp
+++ b/examples/PZEMHardSerial/PZEMHardSerial.cpp
@@ -11,18 +11,8 @@ Note that ESP32 HardwareSerial must also be provided with the RX and TX
 pins.
 
 */
-
+#include <Arduino.h>
 #include <PZEM004Tv30.h>
-
-
-#if !defined(PZEM_RX_PIN) && !defined(PZEM_TX_PIN)
-#define PZEM_RX_PIN 16
-#define PZEM_TX_PIN 17
-#endif
-
-#if !defined(PZEM_SERIAL)
-#define PZEM_SERIAL Serial2
-#endif
 
 
 #if defined(ESP32)
@@ -33,18 +23,26 @@ pins.
  * The ESP32 HW Serial interface can be routed to any GPIO pin 
  * Here we initialize the PZEM on Serial2 with RX/TX pins 16 and 17
  */
+#if !defined(PZEM_RX_PIN) && !defined(PZEM_TX_PIN)
+#define PZEM_RX_PIN 16
+#define PZEM_TX_PIN 17
+#endif
+
+#define PZEM_SERIAL Serial2
+#define CONSOLE_SERIAL Serial
 PZEM004Tv30 pzem(PZEM_SERIAL, PZEM_RX_PIN, PZEM_TX_PIN);
+
 #elif defined(ESP8266)
 /*************************
  *  ESP8266 initialization
  * ---------------------
  * 
- * Not all Arduino boards come with multiple HW Serial ports.
- * Serial2 is for example available on the Arduino MEGA 2560 but not Arduino Uno!
- * The ESP32 HW Serial interface can be routed to any GPIO pin 
- * Here we initialize the PZEM on Serial2 with default pins
+ * esp8266 can connect with PZEM only via Serial0
+ * For console output we use Serial1, which is gpio2 by default
  */
-//PZEM004Tv30 pzem(Serial1);
+#define PZEM_SERIAL Serial
+#define CONSOLE_SERIAL Serial1
+PZEM004Tv30 pzem(PZEM_SERIAL);
 #else
 /*************************
  *  Arduino initialization
@@ -55,12 +53,14 @@ PZEM004Tv30 pzem(PZEM_SERIAL, PZEM_RX_PIN, PZEM_TX_PIN);
  * The ESP32 HW Serial interface can be routed to any GPIO pin 
  * Here we initialize the PZEM on Serial2 with default pins
  */
+#define PZEM_SERIAL Serial2
+#define CONSOLE_SERIAL Serial
 PZEM004Tv30 pzem(PZEM_SERIAL);
 #endif
 
 void setup() {
     // Debugging Serial port
-    Serial.begin(115200);
+    CONSOLE_SERIAL.begin(115200);
 
     // Uncomment in order to reset the internal energy counter
     // pzem.resetEnergy()
@@ -68,8 +68,8 @@ void setup() {
 
 void loop() {
     // Print the custom address of the PZEM
-    Serial.print("Custom Address:");
-    Serial.println(pzem.readAddress(), HEX);
+    CONSOLE_SERIAL.print("Custom Address:");
+    CONSOLE_SERIAL.println(pzem.readAddress(), HEX);
 
     // Read the data from the sensor
     float voltage = pzem.voltage();
@@ -81,30 +81,30 @@ void loop() {
 
     // Check if the data is valid
     if(isnan(voltage)){
-        Serial.println("Error reading voltage");
+        CONSOLE_SERIAL.println("Error reading voltage");
     } else if (isnan(current)) {
-        Serial.println("Error reading current");
+        CONSOLE_SERIAL.println("Error reading current");
     } else if (isnan(power)) {
-        Serial.println("Error reading power");
+        CONSOLE_SERIAL.println("Error reading power");
     } else if (isnan(energy)) {
-        Serial.println("Error reading energy");
+        CONSOLE_SERIAL.println("Error reading energy");
     } else if (isnan(frequency)) {
-        Serial.println("Error reading frequency");
+        CONSOLE_SERIAL.println("Error reading frequency");
     } else if (isnan(pf)) {
-        Serial.println("Error reading power factor");
+        CONSOLE_SERIAL.println("Error reading power factor");
     } else {
 
         // Print the values to the Serial console
-        Serial.print("Voltage: ");      Serial.print(voltage);      Serial.println("V");
-        Serial.print("Current: ");      Serial.print(current);      Serial.println("A");
-        Serial.print("Power: ");        Serial.print(power);        Serial.println("W");
-        Serial.print("Energy: ");       Serial.print(energy,3);     Serial.println("kWh");
-        Serial.print("Frequency: ");    Serial.print(frequency, 1); Serial.println("Hz");
-        Serial.print("PF: ");           Serial.println(pf);
+        CONSOLE_SERIAL.print("Voltage: ");      CONSOLE_SERIAL.print(voltage);      CONSOLE_SERIAL.println("V");
+        CONSOLE_SERIAL.print("Current: ");      CONSOLE_SERIAL.print(current);      CONSOLE_SERIAL.println("A");
+        CONSOLE_SERIAL.print("Power: ");        CONSOLE_SERIAL.print(power);        CONSOLE_SERIAL.println("W");
+        CONSOLE_SERIAL.print("Energy: ");       CONSOLE_SERIAL.print(energy,3);     CONSOLE_SERIAL.println("kWh");
+        CONSOLE_SERIAL.print("Frequency: ");    CONSOLE_SERIAL.print(frequency, 1); CONSOLE_SERIAL.println("Hz");
+        CONSOLE_SERIAL.print("PF: ");           CONSOLE_SERIAL.println(pf);
 
     }
 
 
-    Serial.println();
+    CONSOLE_SERIAL.println();
     delay(2000);
 }

--- a/examples/PZEMHardSerial/platformio.ini
+++ b/examples/PZEMHardSerial/platformio.ini
@@ -9,8 +9,8 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-src_dir = src
-;lib_dir = ../../../
+src_dir = ./
+lib_dir = ../../../
 
 [env]
 framework = arduino

--- a/examples/PZEMHardSerial/platformio.ini
+++ b/examples/PZEMHardSerial/platformio.ini
@@ -9,8 +9,8 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-src_dir = ./
-lib_dir = ../../../
+src_dir = src
+;lib_dir = ../../../
 
 [env]
 framework = arduino
@@ -24,6 +24,8 @@ platform = atmelavr
 board = megaatmega2560
 lib_deps=SoftwareSerial
 lib_ignore=EspSoftwareSerial
+build_flags =
+  -DPZEM004_NO_SWSERIAL
 
 
 ; [env:esp01]
@@ -32,16 +34,16 @@ lib_ignore=EspSoftwareSerial
 ; board = esp01
 ; build_deps=EspSoftwareSerial
 
-; [env:nodemcuv2]
+[env:nodemcuv2]
 ; ; ESP8266 ESP-12
-; platform = espressif8266
-; board = nodemcuv2
-; build_deps=EspSoftwareSerial
-
+platform = espressif8266
+board = nodemcuv2
+lib_ignore=EspSoftwareSerial
+build_flags =
+  -DPZEM004_NO_SWSERIAL
 
 [env:wemos_d1_mini32_hw]
 ; ESP32 Hardware Serial
 platform = espressif32
 board = wemos_d1_mini32
-lib_deps=EspSoftwareSerial
-
+lib_ignore=EspSoftwareSerial

--- a/src/PZEM004Tv30.cpp
+++ b/src/PZEM004Tv30.cpp
@@ -517,7 +517,7 @@ bool PZEM004Tv30::sendCmd8(uint8_t cmd, uint16_t rAddr, uint16_t val, bool check
 uint16_t PZEM004Tv30::receive(uint8_t *resp, uint16_t len)
 {
       //* This has to only be enabled for Software serial
-    #if (defined(PZEM004_SOFTSERIAL) && (defined(__AVR__)) || defined(ESP8266))
+    #if defined(PZEM004_SOFTSERIAL)
         if(_isSoft)
             ((SoftwareSerial *)_serial)->listen(); // Start software serial listen
     #endif

--- a/src/PZEM004Tv30.h
+++ b/src/PZEM004Tv30.h
@@ -46,9 +46,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /* Disable Software Serial completely by defining: */
 // #define PZEM004_NO_SWSERIAL
 
-#if (not defined(PZEM004_NO_SWSERIAL) && (defined(__AVR__) || defined(ESP8266)) && not defined(ESP32))
-/* Software serial is only available for AVRs and ESP8266 */
-#define PZEM004_SOFTSERIAL
+#ifndef PZEM004_NO_SWSERIAL
+ /* Software serial is only available for AVRs and ESP8266 */
+ #if defined(__AVR__) || defined(ESP8266)
+ #define PZEM004_SOFTSERIAL
+ #endif
 #endif
 
 #if defined(PZEM004_SOFTSERIAL)


### PR DESCRIPTION
wrong logic in define's resulted in build error under esp8266 if PZEM004_NO_SWSERIAL was set.
Also updated HWSerial example to be a real HWSerial, no gotchas. So from now on CI job should detect such build issues